### PR TITLE
Fix sync route registration paths

### DIFF
--- a/packages/backend/src/routes/syncRoutes.ts
+++ b/packages/backend/src/routes/syncRoutes.ts
@@ -22,7 +22,7 @@ interface PullQuery {
 export const syncRoutes: FastifyPluginAsync = async (fastify, _opts) => {
 
     fastify.post<{ Body: PushBody }>(
-      '/sync/push', 
+      '/push',
       { schema: { 
           body: {
               type: 'object',
@@ -94,7 +94,7 @@ export const syncRoutes: FastifyPluginAsync = async (fastify, _opts) => {
     });
 
     fastify.get<{ Querystring: PullQuery }>(
-      '/sync/pull', 
+      '/pull',
       { schema: { 
           querystring: { 
               type: 'object', 

--- a/packages/backend/test-backend.ts
+++ b/packages/backend/test-backend.ts
@@ -8,6 +8,18 @@ async function testServer() {
         
         console.log('✓ Server built successfully');
         console.log('✓ All backend components are properly connected');
+
+        const routeTable = app.printRoutes({ commonPrefix: false });
+        console.log(routeTable);
+
+        if (!routeTable.includes('/api/v1/sync/push')) {
+            throw new Error('Sync push route missing from route table');
+        }
+
+        if (!routeTable.includes('/api/v1/sync/pull')) {
+            throw new Error('Sync pull route missing from route table');
+        }
+
         console.log('✓ Sync routes registered at /api/v1/sync/push and /api/v1/sync/pull');
         console.log('✓ JWT authentication middleware configured');
         console.log('✓ PostgreSQL connection service ready');
@@ -15,7 +27,9 @@ async function testServer() {
         // Close the server to finish the test
         await app.close();
         console.log('✓ Test completed successfully');
-        
+
+        process.exit(0);
+
     } catch (error) {
         console.error('✗ Error during server test:', error);
         process.exit(1);


### PR DESCRIPTION
## Summary
- register sync push and pull routes relative to the plugin prefix so they surface at /api/v1/sync
- update the backend test harness to assert the new route locations via Fastify's route table

## Testing
- bun run packages/backend/test-backend.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8c08113fc83238cb96d0b9cf4437e