### PR TITLE
Handle sync timestamps with millisecond precision

### DIFF
--- a/packages/backend/src/routes/__tests__/syncRoutes.test.ts
+++ b/packages/backend/src/routes/__tests__/syncRoutes.test.ts
@@ -35,7 +35,52 @@ describe('syncRoutes timestamp handling', () => {
     await pool.query(`
       CREATE TABLE decks (
         id TEXT PRIMARY KEY,
-        user_id TEXT NOT NULL
+        user_id TEXT NOT NULL,
+        name TEXT,
+        description TEXT,
+        config JSONB DEFAULT '{}'::jsonb,
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+      );
+    `);
+
+    await pool.query(`
+      CREATE TABLE notes (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        deck_id TEXT NOT NULL,
+        model_name TEXT NOT NULL,
+        fields JSONB NOT NULL,
+        tags TEXT[],
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+      );
+    `);
+
+    await pool.query(`
+      CREATE TABLE cards (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        note_id TEXT NOT NULL,
+        ordinal INTEGER NOT NULL,
+        due TIMESTAMPTZ,
+        interval INTEGER,
+        ease_factor REAL,
+        reps INTEGER,
+        lapses INTEGER,
+        card_type INTEGER,
+        queue INTEGER,
+        original_due TIMESTAMPTZ,
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+      );
+    `);
+
+    await pool.query(`
+      CREATE TABLE review_logs (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        card_id TEXT NOT NULL,
+        timestamp TIMESTAMPTZ,
+        rating INTEGER,
+        duration_ms INTEGER
       );
     `);
 
@@ -60,6 +105,9 @@ describe('syncRoutes timestamp handling', () => {
 
   beforeEach(async () => {
     await pool.query('DELETE FROM sync_meta;');
+    await pool.query('DELETE FROM review_logs;');
+    await pool.query('DELETE FROM cards;');
+    await pool.query('DELETE FROM notes;');
     await pool.query('DELETE FROM decks;');
   });
 
@@ -71,6 +119,9 @@ describe('syncRoutes timestamp handling', () => {
 
   it('stores millisecond timestamps as dates and returns them during pull', async () => {
     const timestampMillis = Date.now();
+    const dueMillis = timestampMillis + 1_000;
+    const originalDueMillis = timestampMillis + 2_000;
+    const reviewTimestampMillis = timestampMillis + 3_000;
 
     const pushResponse = await fetch(`${baseUrl}/push`, {
       method: 'POST',
@@ -82,27 +133,102 @@ describe('syncRoutes timestamp handling', () => {
             entityId: 'deck-1',
             entityType: 'deck',
             version: 1,
-            op: 'delete',
+            op: 'create',
             timestamp: timestampMillis,
+            payload: {
+              name: 'Test Deck',
+              description: null,
+              config: {},
+            },
+          },
+          {
+            entityId: 'note-1',
+            entityType: 'note',
+            version: 2,
+            op: 'create',
+            timestamp: timestampMillis + 1,
+            payload: {
+              deck_id: 'deck-1',
+              model_name: 'Basic',
+              fields: { Front: 'Q', Back: 'A' },
+              tags: ['tag'],
+            },
+          },
+          {
+            entityId: 'card-1',
+            entityType: 'card',
+            version: 3,
+            op: 'create',
+            timestamp: timestampMillis + 2,
+            payload: {
+              note_id: 'note-1',
+              ordinal: 0,
+              due: dueMillis,
+              interval: 0,
+              ease_factor: 2.5,
+              reps: 0,
+              lapses: 0,
+              card_type: 1,
+              queue: 0,
+              original_due: originalDueMillis,
+            },
+          },
+          {
+            entityId: 'review-log-1',
+            entityType: 'review_log',
+            version: 4,
+            op: 'create',
+            timestamp: timestampMillis + 3,
+            payload: {
+              card_id: 'card-1',
+              timestamp: reviewTimestampMillis,
+              rating: 4,
+              duration_ms: 1200,
+            },
           },
         ],
       }),
     });
     expect(pushResponse.status).toBe(200);
     const pushBody = await pushResponse.json();
-    expect(pushBody.currentVersion).toBe(1);
+    expect(pushBody.currentVersion).toBe(4);
 
-    const metaRows = await pool.query('SELECT timestamp FROM sync_meta');
-    expect(metaRows.rows).toHaveLength(1);
-    const storedTimestamp: Date = metaRows.rows[0].timestamp;
-    expect(storedTimestamp instanceof Date).toBe(true);
-    expect(storedTimestamp.getTime()).toBe(timestampMillis);
+    const metaRows = await pool.query('SELECT entity_type, version, timestamp FROM sync_meta ORDER BY version ASC');
+    expect(metaRows.rows).toHaveLength(4);
+    metaRows.rows.forEach((row, index) => {
+      expect(row.timestamp).toBeInstanceOf(Date);
+      expect((row.timestamp as Date).getTime()).toBe(timestampMillis + index);
+    });
+
+    const cardRows = await pool.query('SELECT due, original_due FROM cards');
+    expect(cardRows.rows).toHaveLength(1);
+    const cardRow = cardRows.rows[0];
+    expect(cardRow.due).toBeInstanceOf(Date);
+    expect((cardRow.due as Date).getTime()).toBe(dueMillis);
+    expect(cardRow.original_due).toBeInstanceOf(Date);
+    expect((cardRow.original_due as Date).getTime()).toBe(originalDueMillis);
+
+    const reviewRows = await pool.query('SELECT timestamp FROM review_logs');
+    expect(reviewRows.rows).toHaveLength(1);
+    const reviewTimestamp: Date = reviewRows.rows[0].timestamp;
+    expect(reviewTimestamp.getTime()).toBe(reviewTimestampMillis);
 
     const pullResponse = await fetch(`${baseUrl}/pull?sinceVersion=0`);
     expect(pullResponse.status).toBe(200);
     const body = await pullResponse.json();
-    expect(body.ops).toHaveLength(1);
-    const pulledTimestamp = new Date(body.ops[0].timestamp).getTime();
-    expect(pulledTimestamp).toBe(timestampMillis);
+    expect(body.ops).toHaveLength(4);
+
+    const cardOp = body.ops.find((op: any) => op.entityType === 'card');
+    expect(cardOp).toBeTruthy();
+    expect(cardOp.timestamp).toBe(timestampMillis + 2);
+    expect(cardOp.payload.due).toBe(dueMillis);
+    expect(cardOp.payload.original_due).toBe(originalDueMillis);
+    expect('user_id' in cardOp.payload).toBe(false);
+
+    const reviewOp = body.ops.find((op: any) => op.entityType === 'review_log');
+    expect(reviewOp).toBeTruthy();
+    expect(reviewOp.timestamp).toBe(timestampMillis + 3);
+    expect(reviewOp.payload.timestamp).toBe(reviewTimestampMillis);
+    expect(reviewOp.payload.duration_ms).toBe(1200);
   });
 });

--- a/packages/backend/src/routes/syncRoutes.ts
+++ b/packages/backend/src/routes/syncRoutes.ts
@@ -1,22 +1,88 @@
 import { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import { getQueryClient, query, type QueryClient } from '../db/pg-service.js';
 
-interface OpLog {
-    entityId: string;
-    entityType: 'deck' | 'note' | 'card' | 'review_log';
-    version: number;
-    op: 'create' | 'update' | 'delete';
-    timestamp: number;
-    payload?: Record<string, any>;
+type EntityType = 'deck' | 'note' | 'card' | 'review_log';
+type OperationType = 'create' | 'update' | 'delete';
+
+interface DeckPayload {
+    name: string;
+    description?: string | null;
+    config?: Record<string, unknown> | null;
 }
+
+interface NotePayload {
+    deck_id: string;
+    model_name: string;
+    fields: Record<string, unknown>;
+    tags?: string[] | null;
+}
+
+interface CardPayload {
+    note_id: string;
+    ordinal: number;
+    due?: number | null;
+    interval?: number | null;
+    ease_factor?: number | null;
+    reps?: number | null;
+    lapses?: number | null;
+    card_type?: number | null;
+    queue?: number | null;
+    original_due?: number | null;
+}
+
+interface ReviewLogPayload {
+    card_id: string;
+    timestamp?: number | null;
+    rating: number;
+    duration_ms?: number | null;
+}
+
+interface BaseOp {
+    entityId: string;
+    entityType: EntityType;
+    version: number;
+    op: OperationType;
+    timestamp: number;
+}
+
+type CreateOrUpdateOp<TPayload> = BaseOp & {
+    op: 'create' | 'update';
+    payload: TPayload;
+};
+
+type DeleteOp = BaseOp & {
+    op: 'delete';
+    payload?: undefined;
+};
+
+type DeckOp = (CreateOrUpdateOp<DeckPayload> | DeleteOp) & { entityType: 'deck' };
+type NoteOp = (CreateOrUpdateOp<NotePayload> | DeleteOp) & { entityType: 'note' };
+type CardOp = (CreateOrUpdateOp<CardPayload> | DeleteOp) & { entityType: 'card' };
+type ReviewLogOp = (CreateOrUpdateOp<ReviewLogPayload> | DeleteOp) & { entityType: 'review_log' };
+
+type SyncOp = DeckOp | NoteOp | CardOp | ReviewLogOp;
 
 interface PushBody {
     deviceId: string;
-    ops: OpLog[]; 
+    ops: SyncOp[];
 }
 
 interface PullQuery {
     sinceVersion: string;
+}
+
+interface PullResponse {
+    ops: SyncOp[];
+    newVersion: number;
+}
+
+interface SyncMetaRow {
+    entity_id: string;
+    entity_type: EntityType;
+    version: number;
+    op: OperationType;
+    timestamp: Date | string | number;
+    payload?: Record<string, unknown> | null;
 }
 
 export const syncRoutes: FastifyPluginAsync = async (fastify, _opts) => {
@@ -59,7 +125,7 @@ export const syncRoutes: FastifyPluginAsync = async (fastify, _opts) => {
             await client.query('BEGIN');
 
             for (const op of ops) {
-                if (!op.version) { op.version = Date.now(); } // Fallback
+                if (op.version == null) { op.version = Date.now(); }
 
                 // 1. Write to sync_meta (for conflict resolution/versioning)
                 const syncMetaInsert = `
@@ -71,18 +137,29 @@ export const syncRoutes: FastifyPluginAsync = async (fastify, _opts) => {
                 const timestamp = new Date(timestampValue);
 
                 await client.query(syncMetaInsert, [
-                    userId, op.entityId, op.entityType, op.version, op.op, timestamp, op.payload || null
+                    userId,
+                    op.entityId,
+                    op.entityType,
+                    op.version,
+                    op.op,
+                    timestamp,
+                    op.payload ?? null
                 ]);
 
                 // 2. Handle entity operations based on type and operation
-                if (op.entityType === 'deck') {
-                    await handleDeckOperation(client, userId, op);
-                } else if (op.entityType === 'note') {
-                    await handleNoteOperation(client, userId, op);
-                } else if (op.entityType === 'card') {
-                    await handleCardOperation(client, userId, op);
-                } else if (op.entityType === 'review_log') {
-                    await handleReviewLogOperation(client, userId, op);
+                switch (op.entityType) {
+                    case 'deck':
+                        await handleDeckOperation(client, userId, op);
+                        break;
+                    case 'note':
+                        await handleNoteOperation(client, userId, op);
+                        break;
+                    case 'card':
+                        await handleCardOperation(client, userId, op);
+                        break;
+                    case 'review_log':
+                        await handleReviewLogOperation(client, userId, op);
+                        break;
                 }
 
                 latestVersion = Math.max(latestVersion, op.version);
@@ -91,7 +168,7 @@ export const syncRoutes: FastifyPluginAsync = async (fastify, _opts) => {
             await client.query('COMMIT');
 
             return reply.send({ message: `${ops.length} ops processed.`, currentVersion: latestVersion });
-        } catch (error: any) {
+        } catch (error) {
             try {
                 await client.query('ROLLBACK');
             } catch (rollbackError) {
@@ -136,27 +213,17 @@ export const syncRoutes: FastifyPluginAsync = async (fastify, _opts) => {
                 [userId, sinceVersion]
             );
 
-            // For 'create' and 'update' operations, we need to fetch the actual entity data
-            const ops = await Promise.all(metaResults.rows.map(async (op: any) => {
-                if (op.op === 'create' || op.op === 'update') {
-                    // Fetch the actual entity data
-                    const entityData = await fetchEntityData(userId, op.entity_id, op.entity_type as 'deck' | 'note' | 'card' | 'review_log');
-                    return {
-                        ...op,
-                        payload: entityData
-                    };
-                }
-                return op; // For 'delete' operations, payload is not needed
-            })) as any[];
+            const metaRows = metaResults.rows as SyncMetaRow[];
+            const ops = await Promise.all(metaRows.map(row => mapMetaRowToOp(row, userId)));
 
             const highestVersion = ops.length > 0 ? ops[ops.length - 1].version : sinceVersion;
-            
-            return reply.send({
-                ops: ops,
+
+            return reply.send<PullResponse>({
+                ops,
                 newVersion: highestVersion,
             });
 
-        } catch (error: any) {
+        } catch (error) {
             fastify.log.error("Sync Pull failed:", error);
             reply.code(500).send({ error: 'Error pulling changes.' });
         }
@@ -164,26 +231,34 @@ export const syncRoutes: FastifyPluginAsync = async (fastify, _opts) => {
 };
 
 // Helper functions to handle different entity types
-async function handleDeckOperation(client: QueryClient, userId: string, op: OpLog) {
-    if (!op.payload) return;
-
+async function handleDeckOperation(client: QueryClient, userId: string, op: DeckOp) {
     if (op.op === 'create') {
+        const payload = op.payload;
         const insertQuery = `
             INSERT INTO decks (id, user_id, name, description, config)
             VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (id) DO NOTHING;
         `;
         await client.query(insertQuery, [
-            op.entityId, userId, op.payload.name, op.payload.description, op.payload.config || {}
+            op.entityId,
+            userId,
+            payload.name,
+            payload.description ?? null,
+            payload.config ?? {},
         ]);
     } else if (op.op === 'update') {
+        const payload = op.payload;
         const updateQuery = `
             UPDATE decks
             SET name = $1, description = $2, config = $3, updated_at = NOW()
             WHERE id = $4 AND user_id = $5;
         `;
         await client.query(updateQuery, [
-            op.payload.name, op.payload.description, op.payload.config || {}, op.entityId, userId
+            payload.name,
+            payload.description ?? null,
+            payload.config ?? {},
+            op.entityId,
+            userId,
         ]);
     } else if (op.op === 'delete') {
         const deleteQuery = `
@@ -194,28 +269,36 @@ async function handleDeckOperation(client: QueryClient, userId: string, op: OpLo
     }
 }
 
-async function handleNoteOperation(client: QueryClient, userId: string, op: OpLog) {
-    if (!op.payload) return;
-
+async function handleNoteOperation(client: QueryClient, userId: string, op: NoteOp) {
     if (op.op === 'create') {
+        const payload = op.payload;
         const insertQuery = `
             INSERT INTO notes (id, user_id, deck_id, model_name, fields, tags)
             VALUES ($1, $2, $3, $4, $5, $6)
             ON CONFLICT (id) DO NOTHING;
         `;
         await client.query(insertQuery, [
-            op.entityId, userId, op.payload.deck_id, op.payload.model_name, 
-            op.payload.fields, op.payload.tags || []
+            op.entityId,
+            userId,
+            payload.deck_id,
+            payload.model_name,
+            payload.fields,
+            payload.tags ?? [],
         ]);
     } else if (op.op === 'update') {
+        const payload = op.payload;
         const updateQuery = `
             UPDATE notes
             SET deck_id = $1, model_name = $2, fields = $3, tags = $4, updated_at = NOW()
             WHERE id = $5 AND user_id = $6;
         `;
         await client.query(updateQuery, [
-            op.payload.deck_id, op.payload.model_name, op.payload.fields, 
-            op.payload.tags || [], op.entityId, userId
+            payload.deck_id,
+            payload.model_name,
+            payload.fields,
+            payload.tags ?? [],
+            op.entityId,
+            userId,
         ]);
     } else if (op.op === 'delete') {
         const deleteQuery = `
@@ -226,34 +309,54 @@ async function handleNoteOperation(client: QueryClient, userId: string, op: OpLo
     }
 }
 
-async function handleCardOperation(client: QueryClient, userId: string, op: OpLog) {
-    if (!op.payload) return;
-
+async function handleCardOperation(client: QueryClient, userId: string, op: CardOp) {
     if (op.op === 'create') {
+        const payload = op.payload;
         const insertQuery = `
-            INSERT INTO cards (id, user_id, note_id, ordinal, due, interval, ease_factor, 
+            INSERT INTO cards (id, user_id, note_id, ordinal, due, interval, ease_factor,
                               reps, lapses, card_type, queue, original_due)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
             ON CONFLICT (id) DO NOTHING;
         `;
+        const due = payload.due != null ? new Date(payload.due) : new Date();
+        const originalDue = payload.original_due != null ? new Date(payload.original_due) : null;
         await client.query(insertQuery, [
-            op.entityId, userId, op.payload.note_id, op.payload.ordinal, 
-            op.payload.due || new Date(), op.payload.interval || 0, op.payload.ease_factor || 2.5,
-            op.payload.reps || 0, op.payload.lapses || 0, op.payload.card_type || 0, 
-            op.payload.queue || 0, op.payload.original_due || 0
+            op.entityId,
+            userId,
+            payload.note_id,
+            payload.ordinal,
+            due,
+            payload.interval ?? 0,
+            payload.ease_factor ?? 2.5,
+            payload.reps ?? 0,
+            payload.lapses ?? 0,
+            payload.card_type ?? 0,
+            payload.queue ?? 0,
+            originalDue,
         ]);
     } else if (op.op === 'update') {
+        const payload = op.payload;
         const updateQuery = `
             UPDATE cards
             SET note_id = $1, ordinal = $2, due = $3, interval = $4, ease_factor = $5,
                 reps = $6, lapses = $7, card_type = $8, queue = $9, original_due = $10, updated_at = NOW()
             WHERE id = $11 AND user_id = $12;
         `;
+        const due = payload.due != null ? new Date(payload.due) : new Date();
+        const originalDue = payload.original_due != null ? new Date(payload.original_due) : null;
         await client.query(updateQuery, [
-            op.payload.note_id, op.payload.ordinal, op.payload.due, op.payload.interval, 
-            op.payload.ease_factor, op.payload.reps, op.payload.lapses, 
-            op.payload.card_type, op.payload.queue, op.payload.original_due || 0, 
-            op.entityId, userId
+            payload.note_id,
+            payload.ordinal,
+            due,
+            payload.interval ?? 0,
+            payload.ease_factor ?? 2.5,
+            payload.reps ?? 0,
+            payload.lapses ?? 0,
+            payload.card_type ?? 0,
+            payload.queue ?? 0,
+            originalDue,
+            op.entityId,
+            userId,
         ]);
     } else if (op.op === 'delete') {
         const deleteQuery = `
@@ -264,18 +367,22 @@ async function handleCardOperation(client: QueryClient, userId: string, op: OpLo
     }
 }
 
-async function handleReviewLogOperation(client: QueryClient, userId: string, op: OpLog) {
-    if (!op.payload) return;
-
+async function handleReviewLogOperation(client: QueryClient, userId: string, op: ReviewLogOp) {
     if (op.op === 'create') {
+        const payload = op.payload;
         const insertQuery = `
             INSERT INTO review_logs (id, user_id, card_id, timestamp, rating, duration_ms)
             VALUES ($1, $2, $3, $4, $5, $6)
             ON CONFLICT (id) DO NOTHING;
         `;
+        const timestamp = payload.timestamp != null ? new Date(payload.timestamp) : new Date();
         await client.query(insertQuery, [
-            op.entityId, userId, op.payload.card_id, op.payload.timestamp || new Date(), 
-            op.payload.rating, op.payload.duration_ms
+            op.entityId,
+            userId,
+            payload.card_id,
+            timestamp,
+            payload.rating,
+            payload.duration_ms ?? null,
         ]);
     } else if (op.op === 'delete') {
         const deleteQuery = `
@@ -288,31 +395,205 @@ async function handleReviewLogOperation(client: QueryClient, userId: string, op:
 }
 
 // Helper function to fetch entity data for pull operations
-async function fetchEntityData(userId: string, entityId: string, entityType: 'deck' | 'note' | 'card' | 'review_log') {
+async function fetchEntityData(userId: string, entityId: string, entityType: 'deck'): Promise<DeckPayload | null>;
+async function fetchEntityData(userId: string, entityId: string, entityType: 'note'): Promise<NotePayload | null>;
+async function fetchEntityData(userId: string, entityId: string, entityType: 'card'): Promise<CardPayload | null>;
+async function fetchEntityData(userId: string, entityId: string, entityType: 'review_log'): Promise<ReviewLogPayload | null>;
+async function fetchEntityData(userId: string, entityId: string, entityType: EntityType) {
     if (entityType === 'deck') {
         const result = await query(
-            'SELECT * FROM decks WHERE id = $1 AND user_id = $2',
+            'SELECT name, description, config FROM decks WHERE id = $1 AND user_id = $2',
             [entityId, userId]
         );
-        return result.rows[0] || null;
-    } else if (entityType === 'note') {
-        const result = await query(
-            'SELECT * FROM notes WHERE id = $1 AND user_id = $2',
-            [entityId, userId]
-        );
-        return result.rows[0] || null;
-    } else if (entityType === 'card') {
-        const result = await query(
-            'SELECT * FROM cards WHERE id = $1 AND user_id = $2',
-            [entityId, userId]
-        );
-        return result.rows[0] || null;
-    } else if (entityType === 'review_log') {
-        const result = await query(
-            'SELECT * FROM review_logs WHERE id = $1 AND user_id = $2',
-            [entityId, userId]
-        );
-        return result.rows[0] || null;
+        const row = result.rows[0];
+        if (!row) return null;
+        const payload: DeckPayload = {
+            name: row.name,
+            description: row.description ?? null,
+            config: row.config ?? {},
+        };
+        return payload;
     }
-    return null;
+    if (entityType === 'note') {
+        const result = await query(
+            'SELECT deck_id, model_name, fields, tags FROM notes WHERE id = $1 AND user_id = $2',
+            [entityId, userId]
+        );
+        const row = result.rows[0];
+        if (!row) return null;
+        const payload: NotePayload = {
+            deck_id: row.deck_id,
+            model_name: row.model_name,
+            fields: row.fields,
+            tags: row.tags ?? [],
+        };
+        return payload;
+    }
+    if (entityType === 'card') {
+        const result = await query(
+            'SELECT note_id, ordinal, due, interval, ease_factor, reps, lapses, card_type, queue, original_due FROM cards WHERE id = $1 AND user_id = $2',
+            [entityId, userId]
+        );
+        const row = result.rows[0];
+        if (!row) return null;
+        const payload: CardPayload = {
+            note_id: row.note_id,
+            ordinal: row.ordinal,
+            due: toMillisOrNull(row.due),
+            interval: row.interval ?? null,
+            ease_factor: row.ease_factor ?? null,
+            reps: row.reps ?? null,
+            lapses: row.lapses ?? null,
+            card_type: row.card_type ?? null,
+            queue: row.queue ?? null,
+            original_due: toMillisOrNull(row.original_due),
+        };
+        return payload;
+    }
+    const result = await query(
+        'SELECT card_id, timestamp, rating, duration_ms FROM review_logs WHERE id = $1 AND user_id = $2',
+        [entityId, userId]
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    const payload: ReviewLogPayload = {
+        card_id: row.card_id,
+        timestamp: toMillisOrNull(row.timestamp),
+        rating: row.rating,
+        duration_ms: row.duration_ms ?? null,
+    };
+    return payload;
+}
+
+async function mapMetaRowToOp(row: SyncMetaRow, userId: string): Promise<SyncOp> {
+    const version = Number(row.version);
+    const timestamp = toMillis(row.timestamp);
+
+    if (row.entity_type === 'deck') {
+        if (row.op === 'create' || row.op === 'update') {
+            const payload = resolvePayload(await fetchEntityData(userId, row.entity_id, 'deck'), row) as DeckPayload;
+            const op: DeckOp = {
+                entityId: row.entity_id,
+                entityType: 'deck',
+                version,
+                op: row.op,
+                timestamp,
+                payload,
+            };
+            return op;
+        }
+        const op: DeckOp = {
+            entityId: row.entity_id,
+            entityType: 'deck',
+            version,
+            op: row.op,
+            timestamp,
+        };
+        return op;
+    }
+
+    if (row.entity_type === 'note') {
+        if (row.op === 'create' || row.op === 'update') {
+            const payload = resolvePayload(await fetchEntityData(userId, row.entity_id, 'note'), row) as NotePayload;
+            const op: NoteOp = {
+                entityId: row.entity_id,
+                entityType: 'note',
+                version,
+                op: row.op,
+                timestamp,
+                payload,
+            };
+            return op;
+        }
+        const op: NoteOp = {
+            entityId: row.entity_id,
+            entityType: 'note',
+            version,
+            op: row.op,
+            timestamp,
+        };
+        return op;
+    }
+
+    if (row.entity_type === 'card') {
+        if (row.op === 'create' || row.op === 'update') {
+            const payload = resolvePayload(await fetchEntityData(userId, row.entity_id, 'card'), row) as CardPayload;
+            const op: CardOp = {
+                entityId: row.entity_id,
+                entityType: 'card',
+                version,
+                op: row.op,
+                timestamp,
+                payload,
+            };
+            return op;
+        }
+        const op: CardOp = {
+            entityId: row.entity_id,
+            entityType: 'card',
+            version,
+            op: row.op,
+            timestamp,
+        };
+        return op;
+    }
+
+    if (row.op === 'create' || row.op === 'update') {
+        const payload = resolvePayload(await fetchEntityData(userId, row.entity_id, 'review_log'), row) as ReviewLogPayload;
+        const op: ReviewLogOp = {
+            entityId: row.entity_id,
+            entityType: 'review_log',
+            version,
+            op: row.op,
+            timestamp,
+            payload,
+        };
+        return op;
+    }
+    const op: ReviewLogOp = {
+        entityId: row.entity_id,
+        entityType: 'review_log',
+        version,
+        op: row.op,
+        timestamp,
+    };
+    return op;
+}
+
+function toMillis(value: Date | string | number): number {
+    if (value instanceof Date) {
+        return value.getTime();
+    }
+    if (typeof value === 'number') {
+        return value;
+    }
+    const millis = new Date(value).getTime();
+    if (Number.isNaN(millis)) {
+        throw new Error(`Invalid date value: ${value}`);
+    }
+    return millis;
+}
+
+function toMillisOrNull(value: Date | string | number | null | undefined): number | null {
+    if (value === null || value === undefined) {
+        return null;
+    }
+    if (value instanceof Date) {
+        return value.getTime();
+    }
+    if (typeof value === 'number') {
+        return value;
+    }
+    const millis = new Date(value).getTime();
+    return Number.isNaN(millis) ? null : millis;
+}
+
+function resolvePayload<T>(payload: T | null, row: SyncMetaRow): T {
+    if (payload) {
+        return payload;
+    }
+    if (row.payload) {
+        return row.payload as T;
+    }
+    throw new Error(`Missing payload for ${row.entity_type} ${row.entity_id} (${row.op})`);
 }


### PR DESCRIPTION
## Summary
- type the sync push payloads and convert millisecond timestamps into Date values before touching the database
- normalize pull responses to return numeric timestamps and exclude server-only fields
- extend the sync route tests to cover card and review log timestamp round-trips

## Testing
- bun test src/routes/__tests__/syncRoutes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8d48ab4d083239f5c91e3794f61e5