### PR TITLE
Fix sync_meta ON CONFLICT target and update tests

### DIFF
--- a/packages/backend/src/routes/__tests__/syncRoutes.test.ts
+++ b/packages/backend/src/routes/__tests__/syncRoutes.test.ts
@@ -27,7 +27,6 @@ describe('syncRoutes timestamp handling', () => {
         op TEXT NOT NULL,
         timestamp TIMESTAMPTZ NOT NULL,
         payload JSONB,
-        UNIQUE(entity_id, version),
         UNIQUE(user_id, entity_id, version)
       );
     `);

--- a/packages/backend/src/routes/syncRoutes.ts
+++ b/packages/backend/src/routes/syncRoutes.ts
@@ -131,7 +131,7 @@ export const syncRoutes: FastifyPluginAsync = async (fastify, _opts) => {
                 const syncMetaInsert = `
                     INSERT INTO sync_meta (user_id, entity_id, entity_type, version, op, timestamp, payload)
                     VALUES ($1, $2, $3, $4, $5, $6, $7)
-                    ON CONFLICT (entity_id, version) DO NOTHING;
+                    ON CONFLICT (user_id, entity_id, version) DO NOTHING;
                 `;
                 const timestampValue = Number.isFinite(op.timestamp) ? op.timestamp : Date.now();
                 const timestamp = new Date(timestampValue);


### PR DESCRIPTION
## Summary
- correct the sync_meta ON CONFLICT clause to use the user-specific constraint
- update the pg-mem test schema to match the production uniqueness constraint

## Testing
- bun test src/routes/__tests__/syncRoutes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8d8c94d74832399ca637cee5b0109