### PR TITLE
Fix integer handling for card original due timestamps

### DIFF
--- a/packages/backend/src/routes/__tests__/syncRoutes.test.ts
+++ b/packages/backend/src/routes/__tests__/syncRoutes.test.ts
@@ -67,7 +67,7 @@ describe('syncRoutes timestamp handling', () => {
         lapses INTEGER,
         card_type INTEGER,
         queue INTEGER,
-        original_due TIMESTAMPTZ,
+        original_due INTEGER,
         updated_at TIMESTAMPTZ DEFAULT NOW()
       );
     `);
@@ -204,8 +204,8 @@ describe('syncRoutes timestamp handling', () => {
     const cardRow = cardRows.rows[0];
     expect(cardRow.due).toBeInstanceOf(Date);
     expect((cardRow.due as Date).getTime()).toBe(dueMillis);
-    expect(cardRow.original_due).toBeInstanceOf(Date);
-    expect((cardRow.original_due as Date).getTime()).toBe(originalDueMillis);
+    expect(typeof cardRow.original_due).toBe('number');
+    expect(cardRow.original_due).toBe(originalDueMillis);
 
     const reviewRows = await pool.query('SELECT timestamp FROM review_logs');
     expect(reviewRows.rows).toHaveLength(1);

--- a/packages/backend/src/routes/syncRoutes.ts
+++ b/packages/backend/src/routes/syncRoutes.ts
@@ -319,7 +319,7 @@ async function handleCardOperation(client: QueryClient, userId: string, op: Card
             ON CONFLICT (id) DO NOTHING;
         `;
         const due = payload.due != null ? new Date(payload.due) : new Date();
-        const originalDue = payload.original_due != null ? new Date(payload.original_due) : null;
+        const originalDue = payload.original_due ?? null;
         await client.query(insertQuery, [
             op.entityId,
             userId,
@@ -343,7 +343,7 @@ async function handleCardOperation(client: QueryClient, userId: string, op: Card
             WHERE id = $11 AND user_id = $12;
         `;
         const due = payload.due != null ? new Date(payload.due) : new Date();
-        const originalDue = payload.original_due != null ? new Date(payload.original_due) : null;
+        const originalDue = payload.original_due ?? null;
         await client.query(updateQuery, [
             payload.note_id,
             payload.ordinal,
@@ -446,7 +446,7 @@ async function fetchEntityData(userId: string, entityId: string, entityType: Ent
             lapses: row.lapses ?? null,
             card_type: row.card_type ?? null,
             queue: row.queue ?? null,
-            original_due: toMillisOrNull(row.original_due),
+            original_due: row.original_due ?? null,
         };
         return payload;
     }


### PR DESCRIPTION
## Summary
- store card original_due values as integers in syncRoutes when inserting and updating
- return the stored integer directly from fetchEntityData
- update the sync route pg-mem schema and assertions to cover integer original_due handling

## Testing
- bun test packages/backend/src/routes/__tests__/syncRoutes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8d9d3aa3c83239a7ff66c595b34cd