### PR TITLE
Handle unauthorized sync prehandler and add test

### DIFF
--- a/packages/backend/src/__tests__/authPreHandler.test.ts
+++ b/packages/backend/src/__tests__/authPreHandler.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import type { FastifyInstance } from 'fastify';
+import { setTestPool } from '../db/pg-service.js';
+
+let buildApp: typeof import('../index.js')['buildApp'];
+
+describe('buildApp auth preHandler', () => {
+  let app: FastifyInstance;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    ({ buildApp } = await import('../index.js'));
+    setTestPool({
+      connect: async () => {
+        throw new Error('Database should not be accessed for unauthorized requests');
+      },
+      query: async () => {
+        throw new Error('Database should not be accessed for unauthorized requests');
+      },
+      end: async () => {}
+    } as any);
+    app = await buildApp();
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const address = app.server.address();
+    if (typeof address === 'object' && address) {
+      baseUrl = `http://${address.address}:${address.port}`;
+    } else if (typeof address === 'string') {
+      baseUrl = address;
+    } else {
+      throw new Error('Failed to determine Fastify server address for tests');
+    }
+  });
+
+  afterAll(async () => {
+    setTestPool(null);
+    await app.close();
+  });
+
+  it('returns 401 for unauthenticated push requests', async () => {
+    const response = await fetch(`${baseUrl}/api/v1/sync/push`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        deviceId: 'test-device',
+        ops: [],
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      statusCode: 401,
+      message: 'Missing or invalid Authorization header',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- update the sync pre-handler to surface JWT verification errors instead of swallowing them and guard against accidental server startup during tests
- refactor JWT verification to throw typed unauthorized errors and add a regression test to ensure unauthenticated push requests return 401

## Testing
- `NODE_ENV=test bun test src/__tests__/authPreHandler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d8da8ca4708323a1b1a3c8fb4cce3b