### PR TITLE
Refine sync schemas and share types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ repomix-output*
 
 
 supabase
+node_modules/
+packages/*/node_modules/
+dist/

--- a/packages/backend/bun.lock
+++ b/packages/backend/bun.lock
@@ -8,8 +8,10 @@
         "@fastify/jwt": "^8.0.0",
         "@fastify/postgres": "^5.2.2",
         "fastify": "^4.27.0",
+        "fastify-type-provider-zod": "^2.0.0",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.11.5",
+        "zod": "^3.23.8",
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.6",
@@ -116,6 +118,8 @@
     "fastify": ["fastify@4.29.1", "", { "dependencies": { "@fastify/ajv-compiler": "^3.5.0", "@fastify/error": "^3.4.0", "@fastify/fast-json-stringify-compiler": "^4.3.0", "abstract-logging": "^2.0.1", "avvio": "^8.3.0", "fast-content-type-parse": "^1.1.0", "fast-json-stringify": "^5.8.0", "find-my-way": "^8.0.0", "light-my-request": "^5.11.0", "pino": "^9.0.0", "process-warning": "^3.0.0", "proxy-addr": "^2.0.7", "rfdc": "^1.3.0", "secure-json-parse": "^2.7.0", "semver": "^7.5.4", "toad-cache": "^3.3.0" } }, "sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ=="],
 
     "fastify-plugin": ["fastify-plugin@4.5.1", "", {}, "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ=="],
+
+    "fastify-type-provider-zod": ["fastify-type-provider-zod@2.1.0", "", { "dependencies": { "zod-to-json-schema": "^3.23.0" }, "peerDependencies": { "fastify": "^4.0.0", "zod": "^3.14.2" } }, "sha512-p0plQyrxVR1IxJaOVbKRkduYh74HAS6Pm2szhFrc/vFdfIEu8UWo/cPFZCrcKyeo8ICjWbHH1zkx8lWw/ivpqg=="],
 
     "fastparallel": ["fastparallel@2.4.1", "", { "dependencies": { "reusify": "^1.0.4", "xtend": "^4.0.2" } }, "sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q=="],
 
@@ -292,6 +296,10 @@
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
     "ajv/fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,8 +20,10 @@
     "@fastify/jwt": "^8.0.0",
     "@fastify/postgres": "^5.2.2",
     "fastify": "^4.27.0",
+    "fastify-type-provider-zod": "^2.0.0",
     "jsonwebtoken": "^9.0.2",
-    "pg": "^8.11.5"
+    "pg": "^8.11.5",
+    "zod": "^3.23.8"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/backend/src/__tests__/authPreHandler.test.ts
+++ b/packages/backend/src/__tests__/authPreHandler.test.ts
@@ -43,7 +43,15 @@ describe('buildApp auth preHandler', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         deviceId: 'test-device',
-        ops: [],
+        ops: [
+          {
+            entityId: 'deck-1',
+            entityType: 'deck',
+            version: Date.now(),
+            op: 'delete',
+            timestamp: Date.now(),
+          },
+        ],
       }),
     });
 

--- a/packages/backend/src/routes/__tests__/syncRoutes.test.ts
+++ b/packages/backend/src/routes/__tests__/syncRoutes.test.ts
@@ -199,13 +199,19 @@ describe('syncRoutes timestamp handling', () => {
       expect((row.timestamp as Date).getTime()).toBe(timestampMillis + index);
     });
 
-    const cardRows = await pool.query('SELECT due, original_due FROM cards');
+    const cardRows = await pool.query('SELECT due, original_due, interval, ease_factor, reps, lapses, card_type, queue FROM cards');
     expect(cardRows.rows).toHaveLength(1);
     const cardRow = cardRows.rows[0];
     expect(cardRow.due).toBeInstanceOf(Date);
     expect((cardRow.due as Date).getTime()).toBe(dueMillis);
     expect(typeof cardRow.original_due).toBe('number');
     expect(cardRow.original_due).toBe(originalDueMillis);
+    expect(cardRow.interval).toBe(0);
+    expect(cardRow.ease_factor).toBeCloseTo(2.5);
+    expect(cardRow.reps).toBe(0);
+    expect(cardRow.lapses).toBe(0);
+    expect(cardRow.card_type).toBe(1);
+    expect(cardRow.queue).toBe(0);
 
     const reviewRows = await pool.query('SELECT timestamp FROM review_logs');
     expect(reviewRows.rows).toHaveLength(1);
@@ -219,13 +225,21 @@ describe('syncRoutes timestamp handling', () => {
 
     const cardOp = body.ops.find((op: any) => op.entityType === 'card');
     expect(cardOp).toBeTruthy();
+    expect(typeof cardOp.timestamp).toBe('number');
     expect(cardOp.timestamp).toBe(timestampMillis + 2);
     expect(cardOp.payload.due).toBe(dueMillis);
     expect(cardOp.payload.original_due).toBe(originalDueMillis);
+    expect(cardOp.payload.interval).toBe(0);
+    expect(cardOp.payload.ease_factor).toBe(2.5);
+    expect(cardOp.payload.reps).toBe(0);
+    expect(cardOp.payload.lapses).toBe(0);
+    expect(cardOp.payload.card_type).toBe(1);
+    expect(cardOp.payload.queue).toBe(0);
     expect('user_id' in cardOp.payload).toBe(false);
 
     const reviewOp = body.ops.find((op: any) => op.entityType === 'review_log');
     expect(reviewOp).toBeTruthy();
+    expect(typeof reviewOp.timestamp).toBe('number');
     expect(reviewOp.timestamp).toBe(timestampMillis + 3);
     expect(reviewOp.payload.timestamp).toBe(reviewTimestampMillis);
     expect(reviewOp.payload.duration_ms).toBe(1200);

--- a/packages/frontend/bun.lock
+++ b/packages/frontend/bun.lock
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.25.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.13",
+        "zod": "^3.23.8",
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -626,6 +627,8 @@
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -25,7 +25,8 @@
     "react-dom": "^19.1.1",
     "react-router-dom": "^6.25.1",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.13"
+    "tailwindcss": "^4.1.13",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/packages/frontend/src/core/db/db.ts
+++ b/packages/frontend/src/core/db/db.ts
@@ -1,85 +1,32 @@
-import Dexie, { type Table } from 'dexie'
+import Dexie, { type Table } from 'dexie';
+import {
+  type Card,
+  type Deck,
+  type Note,
+  type NoteType,
+  type ReviewLog,
+  type SyncMeta,
+} from '../../../../shared/src/index.js';
 
-// 核心数据模型类型 (简化版，仅用于 DB 定义)
-// 实际类型应在 features/* 模块中定义
-export interface Deck {
-  id: string // UUID
-  name: string
-  parentId: string | null
-  config: { // 优化: 明确 config 结构
-    description?: string;
-    difficulty: "easy" | "medium" | "hard" | "auto"; // 新增难度字段
-    algorithmConfig?: Record<string, any>; // 算法参数等配置
-    [key: string]: any; 
-  }
-  createdAt: number
-  updatedAt: number
-}
-
-export interface NoteType {
-  id: string
-  name: string
-  fieldDefs: { name: string; type: 'text' | 'rich' }[]
-  templateDefs: { name: string; qfmt: string; afmt: string }[]
-}
-
-export interface Note {
-  id: string
-  noteTypeId: string
-  fields: Record<string, string> // KV 字段值
-  tags: string[]
-  guid: string // 用于同步
-}
-
-export interface Card {
-  id: string
-  noteId: string
-  deckId: string
-  templateIndex: number // 对应 NoteType.templateDefs 的索引
-  state: 'new' | 'learning' | 'review' | 'suspended' | 'buried'
-  due: number // 下次复习时间 (Unix Timestamp)
-  ivl: number // 间隔天数
-  ease: number // 易度/保持率 (算法相关)
-}
-
-export interface ReviewLog {
-  id: string
-  cardId: string
-  timestamp: number
-  rating: number // 1:Again, 2:Hard, 3:Good, 4:Easy
-  durationMs: number
-  // 可选: before/after 状态快照 (用于事件溯源)
-}
-
-export interface SyncMeta {
-  entityId: string
-  entityType: string
-  version: number // HLC/Lamport version
-  op: 'create' | 'update' | 'delete'
-  timestamp: number
-}
-
-// Dexie 数据库类
 export class OpenAnkiDB extends Dexie {
-  decks!: Table<Deck>
-  noteTypes!: Table<NoteType>
-  notes!: Table<Note>
-  cards!: Table<Card>
-  reviewLogs!: Table<ReviewLog>
-  syncMeta!: Table<SyncMeta>
+  decks!: Table<Deck>;
+  noteTypes!: Table<NoteType>;
+  notes!: Table<Note>;
+  cards!: Table<Card>;
+  reviewLogs!: Table<ReviewLog>;
+  syncMeta!: Table<SyncMeta>;
 
   constructor() {
-    super('OpenAnkiDB')
+    super('OpenAnkiDB');
     this.version(1).stores({
       decks: '++id, parentId',
       noteTypes: '++id',
       notes: '++id, guid, *tags, noteTypeId',
-      cards: '++id, deckId, [state+due], state, noteId', // due 索引对调度很重要
+      cards: '++id, deckId, [state+due], state, noteId',
       reviewLogs: '++id, cardId, timestamp',
       syncMeta: '++id, entityId, entityType',
-    })
-    // 如果将来需要升级版本，可以链式调用 this.version(2).stores(...)
+    });
   }
 }
 
-export const db = new OpenAnkiDB()
+export const db = new OpenAnkiDB();

--- a/packages/shared/bun.lock
+++ b/packages/shared/bun.lock
@@ -1,0 +1,14 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@open-anki/shared",
+      "dependencies": {
+        "zod": "^3.23.8",
+      },
+    },
+  },
+  "packages": {
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@open-anki/shared",
+  "version": "0.0.1",
+  "type": "module",
+  "dependencies": {
+    "zod": "^3.23.8"
+  }
+}

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -1,0 +1,68 @@
+export interface DeckConfig {
+  description?: string;
+  difficulty: 'easy' | 'medium' | 'hard' | 'auto';
+  algorithmConfig?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface Deck {
+  id: string;
+  name: string;
+  parentId: string | null;
+  config: DeckConfig;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface NoteTypeFieldDef {
+  name: string;
+  type: 'text' | 'rich';
+}
+
+export interface NoteTypeTemplateDef {
+  name: string;
+  qfmt: string;
+  afmt: string;
+}
+
+export interface NoteType {
+  id: string;
+  name: string;
+  fieldDefs: NoteTypeFieldDef[];
+  templateDefs: NoteTypeTemplateDef[];
+}
+
+export interface Note {
+  id: string;
+  noteTypeId: string;
+  fields: Record<string, string>;
+  tags: string[];
+  guid: string;
+}
+
+export interface Card {
+  id: string;
+  noteId: string;
+  deckId: string;
+  templateIndex: number;
+  state: 'new' | 'learning' | 'review' | 'suspended' | 'buried';
+  due: number;
+  ivl: number;
+  ease: number;
+}
+
+export interface ReviewLog {
+  id: string;
+  cardId: string;
+  timestamp: number;
+  rating: number;
+  durationMs: number;
+}
+
+export interface SyncMeta {
+  entityId: string;
+  entityType: string;
+  version: number;
+  op: 'create' | 'update' | 'delete';
+  timestamp: number;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from './db.js';
+export * from './sync.js';

--- a/packages/shared/src/sync.ts
+++ b/packages/shared/src/sync.ts
@@ -1,0 +1,145 @@
+import { z } from 'zod';
+
+export const deckPayloadSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  config: z.record(z.string(), z.unknown()).nullable().optional(),
+});
+
+export type DeckPayload = z.infer<typeof deckPayloadSchema>;
+
+export const notePayloadSchema = z.object({
+  deck_id: z.string(),
+  model_name: z.string(),
+  fields: z.record(z.string(), z.unknown()),
+  tags: z.array(z.string()).optional(),
+});
+
+export type NotePayload = z.infer<typeof notePayloadSchema>;
+
+export const cardPayloadSchema = z.object({
+  note_id: z.string(),
+  ordinal: z.number(),
+  due: z.number(),
+  interval: z.number(),
+  ease_factor: z.number(),
+  reps: z.number(),
+  lapses: z.number(),
+  card_type: z.number(),
+  queue: z.number(),
+  original_due: z.number().nullable(),
+});
+
+export type CardPayload = z.infer<typeof cardPayloadSchema>;
+
+export const reviewLogPayloadSchema = z.object({
+  card_id: z.string(),
+  timestamp: z.number(),
+  rating: z.number(),
+  duration_ms: z.number().nullable().optional(),
+});
+
+export type ReviewLogPayload = z.infer<typeof reviewLogPayloadSchema>;
+
+export const entityTypeSchema = z.enum(['deck', 'note', 'card', 'review_log']);
+export type EntityType = z.infer<typeof entityTypeSchema>;
+
+export const operationTypeSchema = z.enum(['create', 'update', 'delete']);
+export type OperationType = z.infer<typeof operationTypeSchema>;
+
+const baseOpSchema = z.object({
+  entityId: z.string(),
+  entityType: entityTypeSchema,
+  version: z.number(),
+  op: operationTypeSchema,
+  timestamp: z.number(),
+});
+
+const createOrUpdateDeckOpSchema = baseOpSchema.extend({
+  entityType: z.literal('deck'),
+  op: z.enum(['create', 'update']),
+  payload: deckPayloadSchema,
+});
+
+const createOrUpdateNoteOpSchema = baseOpSchema.extend({
+  entityType: z.literal('note'),
+  op: z.enum(['create', 'update']),
+  payload: notePayloadSchema,
+});
+
+const createOrUpdateCardOpSchema = baseOpSchema.extend({
+  entityType: z.literal('card'),
+  op: z.enum(['create', 'update']),
+  payload: cardPayloadSchema,
+});
+
+const createOrUpdateReviewLogOpSchema = baseOpSchema.extend({
+  entityType: z.literal('review_log'),
+  op: z.enum(['create', 'update']),
+  payload: reviewLogPayloadSchema,
+});
+
+const deleteDeckOpSchema = baseOpSchema.extend({
+  entityType: z.literal('deck'),
+  op: z.literal('delete'),
+  payload: z.undefined(),
+});
+
+const deleteNoteOpSchema = baseOpSchema.extend({
+  entityType: z.literal('note'),
+  op: z.literal('delete'),
+  payload: z.undefined(),
+});
+
+const deleteCardOpSchema = baseOpSchema.extend({
+  entityType: z.literal('card'),
+  op: z.literal('delete'),
+  payload: z.undefined(),
+});
+
+const deleteReviewLogOpSchema = baseOpSchema.extend({
+  entityType: z.literal('review_log'),
+  op: z.literal('delete'),
+  payload: z.undefined(),
+});
+
+const deckOpSchema = z.union([createOrUpdateDeckOpSchema, deleteDeckOpSchema]);
+const noteOpSchema = z.union([createOrUpdateNoteOpSchema, deleteNoteOpSchema]);
+const cardOpSchema = z.union([createOrUpdateCardOpSchema, deleteCardOpSchema]);
+const reviewLogOpSchema = z.union([createOrUpdateReviewLogOpSchema, deleteReviewLogOpSchema]);
+
+export const syncOpSchema = z.union([
+  deckOpSchema,
+  noteOpSchema,
+  cardOpSchema,
+  reviewLogOpSchema,
+]);
+
+export type SyncOp = z.infer<typeof syncOpSchema>;
+
+export const pushBodySchema = z.object({
+  deviceId: z.string(),
+  ops: z.array(syncOpSchema).min(1),
+});
+
+export type PushBody = z.infer<typeof pushBodySchema>;
+
+export const pullQuerySchema = z.object({
+  sinceVersion: z.coerce.number().int().nonnegative(),
+});
+
+export type PullQuery = z.infer<typeof pullQuerySchema>;
+
+export const pushResponseSchema = z.object({
+  message: z.string(),
+  currentVersion: z.number(),
+});
+
+export type PushResponse = z.infer<typeof pushResponseSchema>;
+
+export const pullResponseSchema = z.object({
+  ops: z.array(syncOpSchema),
+  newVersion: z.number(),
+});
+
+export type PullResponse = z.infer<typeof pullResponseSchema>;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a shared workspace that exports Dexie models and zod-based sync schemas
- update the sync routes to use the shared schemas with fastify-type-provider-zod and stricter payload handling
- reuse the shared types in the frontend Dexie database and expand tests for numeric SRS round-trips

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d8e1ef35608323ba2b6301629546e0