### PR TITLE
Handle sync conflicts with per-entity version checks

### DIFF
--- a/packages/shared/src/sync.ts
+++ b/packages/shared/src/sync.ts
@@ -53,6 +53,7 @@ const baseOpSchema = z.object({
   version: z.number(),
   op: operationTypeSchema,
   timestamp: z.number(),
+  diff: z.unknown().optional(),
 });
 
 const createOrUpdateDeckOpSchema = baseOpSchema.extend({


### PR DESCRIPTION
## Summary
- add per-entity version guards to the sync push endpoint and surface 409 conflict responses with retry guidance
- persist the pushing device id and optional diff metadata alongside each sync_meta insert
- extend sync route tests to cover conflict handling and the new metadata columns

## Testing
- bun test src/routes/__tests__/syncRoutes.test.ts src/routes/__tests__/syncRoutes.transaction.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8e7ad81748323b34f49925bf3845c