### PR TITLE
Normalize sync timestamps and tighten payload validation

### DIFF
--- a/packages/backend/src/db/pg-service.ts
+++ b/packages/backend/src/db/pg-service.ts
@@ -23,7 +23,7 @@ const getPool = () => {
   return activePool;
 };
 
-export const query = (text: string, params: any[] = []) => {
+export const query = (text: string, params: readonly unknown[] = []) => {
   return getPool().query(text, params);
 };
 


### PR DESCRIPTION
## Summary
- convert sync_meta, card, and review log operations to coerce millisecond inputs into Date objects before hitting Postgres
- harden pull serialization by validating numeric payload fields and normalizing database rows back into millisecond timestamps
- expose a typed query helper signature to avoid implicit any usage during parameterized queries

## Testing
- `cd packages/backend && bun test`


------
https://chatgpt.com/codex/tasks/task_e_68d8bf8f0e44832399540596572b72ce