### PR TITLE
Require Supabase JWT secret configuration for sync service

### DIFF
--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -17,6 +17,9 @@ introducing the bundled production build.
 - Environment variables can be supplied through your shell or a `.env` file.
   `NODE_ENV` defaults to `development` during local work which enables the
   pretty logger transport.
+- The sync service **requires** `SUPABASE_JWT_SECRET` to be set. This value must
+  match the JWT secret configured for your Supabase project so that incoming
+  tokens can be verified during request authentication.
 
 When you need a clean slate, stop the Supabase stack with `supabase stop` and
 reset the database with `supabase db reset`, then rerun `bun run migrate && bun

--- a/packages/backend/src/__tests__/authPreHandler.test.ts
+++ b/packages/backend/src/__tests__/authPreHandler.test.ts
@@ -7,9 +7,12 @@ let buildApp: typeof import('../index.js')['buildApp'];
 describe('buildApp auth preHandler', () => {
   let app: FastifyInstance;
   let baseUrl: string;
+  const ORIGINAL_SECRET = process.env.SUPABASE_JWT_SECRET;
+  const TEST_SECRET = 'test-secret';
 
   beforeAll(async () => {
     process.env.NODE_ENV = 'test';
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET;
     ({ buildApp } = await import('../index.js'));
     setTestPool({
       connect: async () => {
@@ -35,6 +38,11 @@ describe('buildApp auth preHandler', () => {
   afterAll(async () => {
     setTestPool(null);
     await app.close();
+    if (ORIGINAL_SECRET === undefined) {
+      delete process.env.SUPABASE_JWT_SECRET;
+    } else {
+      process.env.SUPABASE_JWT_SECRET = ORIGINAL_SECRET;
+    }
   });
 
   it('returns 401 for unauthenticated push requests', async () => {

--- a/packages/backend/src/auth/__tests__/authPlugin.test.ts
+++ b/packages/backend/src/auth/__tests__/authPlugin.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { resolveJwtSecret } from '../authPlugin.js';
+
+describe('resolveJwtSecret', () => {
+  const originalSecret = process.env.SUPABASE_JWT_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.SUPABASE_JWT_SECRET;
+    } else {
+      process.env.SUPABASE_JWT_SECRET = originalSecret;
+    }
+  });
+
+  it('throws when SUPABASE_JWT_SECRET is not defined', () => {
+    delete process.env.SUPABASE_JWT_SECRET;
+    expect(() => resolveJwtSecret()).toThrowError(
+      /SUPABASE_JWT_SECRET environment variable must be set/
+    );
+  });
+});

--- a/packages/backend/src/auth/authPlugin.ts
+++ b/packages/backend/src/auth/authPlugin.ts
@@ -11,8 +11,17 @@ declare module 'fastify' {
 }
 
 // 确保在环境变量中设置了 SUPABASE_JWT_SECRET
-const resolveJwtSecret = () =>
-    process.env.SUPABASE_JWT_SECRET || 'your_super_secret_jwt_key_from_supabase_config';
+export const resolveJwtSecret = () => {
+    const secret = process.env.SUPABASE_JWT_SECRET?.trim();
+
+    if (secret) {
+        return secret;
+    }
+
+    throw new Error(
+        'SUPABASE_JWT_SECRET environment variable must be set to verify Supabase JWTs.'
+    );
+};
 
 
 /**

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,7 +1,7 @@
 import Fastify, { FastifyReply, FastifyRequest } from 'fastify';
 import cors from '@fastify/cors';
 import { syncRoutes } from './routes/syncRoutes.js';
-import { verifyJWT } from './auth/authPlugin.js';
+import { resolveJwtSecret, verifyJWT } from './auth/authPlugin.js';
 
 const nodeEnv = process.env.NODE_ENV ?? 'development';
 const isProduction = nodeEnv === 'production';
@@ -26,6 +26,16 @@ export async function buildApp() {
               },
     });
 
+    try {
+        resolveJwtSecret();
+    } catch (err) {
+        fastify.log.error(
+            { err },
+            'SUPABASE_JWT_SECRET environment variable must be provided before starting the sync service.'
+        );
+        throw err;
+    }
+
     // 1. CORS 配置
     await fastify.register(cors, {
         origin: '*', // 生产环境需限制为前端域名
@@ -39,8 +49,22 @@ export async function buildApp() {
             try {
                 await verifyJWT(request, reply);
             } catch (err) {
-                const statusCode = (err as { statusCode?: number })?.statusCode ?? 401;
                 const message = err instanceof Error ? err.message : 'Unauthorized';
+
+                if (message.includes('SUPABASE_JWT_SECRET')) {
+                    request.log.error(
+                        { err },
+                        'Supabase JWT secret is not configured. Rejecting authenticated request.'
+                    );
+                    reply.code(500).send({
+                        statusCode: 500,
+                        error: 'Internal Server Error',
+                        message,
+                    });
+                    return;
+                }
+
+                const statusCode = (err as { statusCode?: number })?.statusCode ?? 401;
                 reply.code(statusCode).send({
                     statusCode,
                     error: 'Unauthorized',
@@ -66,13 +90,18 @@ export async function buildApp() {
 const PORT = parseInt(process.env.PORT || '3000', 10);
 
 if (process.env.NODE_ENV !== 'test') {
-    buildApp().then(app => {
-        app.listen({ port: PORT, host: '0.0.0.0' }, (err, address) => {
-            if (err) {
-                app.log.error({ err }, 'Failed to start sync service');
-                process.exit(1);
-            }
-            app.log.info({ event: 'server_started', address, port: PORT, env: process.env.NODE_ENV ?? 'development' }, 'Sync Service is listening');
+    buildApp()
+        .then(app => {
+            app.listen({ port: PORT, host: '0.0.0.0' }, (err, address) => {
+                if (err) {
+                    app.log.error({ err }, 'Failed to start sync service');
+                    process.exit(1);
+                }
+                app.log.info({ event: 'server_started', address, port: PORT, env: process.env.NODE_ENV ?? 'development' }, 'Sync Service is listening');
+            });
+        })
+        .catch(err => {
+            console.error('Failed to initialize Fastify application:', err);
+            process.exit(1);
         });
-    });
 }


### PR DESCRIPTION
## Summary
- throw when SUPABASE_JWT_SECRET is missing and surface the configuration error during Fastify startup
- harden the auth pre-handler logging and bootstrapping so the server fails fast without a JWT secret
- document the mandatory environment variable and cover the resolver with a unit test

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d92aa467688323b35522db8f4e5679