### PR TITLE
Add Supabase-backed login flow

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,7 +1,4 @@
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from 'react-router-dom';
+import { Navigate, Outlet, RouterProvider, createBrowserRouter, useLocation } from 'react-router-dom';
 import { LayoutWrapper } from './pages/Layout';
 import { Dashboard } from './pages/Dashboard';
 import { ReviewPage } from './pages/ReviewPage';
@@ -11,63 +8,99 @@ import { SettingsPage } from './pages/SettingsPage';
 import { DeckDetailPage } from './pages/DeckDetailPage';
 import { SyncProvider } from './hooks/useSyncEngine';
 import { AuthProvider, useAuth } from './hooks/useAuth';
+import { LoginPage } from './pages/LoginPage';
 
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <LayoutWrapper />,
-    children: [
-      {
-        path: '/',
-        element: <Dashboard />,
-      },
-      {
-        path: 'review',
-        element: <ReviewPage />,
-      },
-      {
-        path: 'decks',
-        element: <DecksPage />,
-      },
-      {
-        path: 'decks/:deckId',
-        element: <DeckDetailPage />,
-      },
-      {
-        path: 'stats',
-        element: <StatsPage />,
-      },
-      {
-        path: 'settings',
-        element: <SettingsPage />,
-      },
-    ],
-  },
-]);
+function LoadingScreen(): JSX.Element {
+  return (
+    <div className="flex h-screen w-full items-center justify-center" role="status" aria-live="polite">
+      <div className="h-12 w-12 animate-spin rounded-full border-4 border-muted border-t-primary" aria-hidden="true" />
+      <span className="sr-only">加载中...</span>
+    </div>
+  );
+}
 
-function ProtectedApp(): JSX.Element {
+function ProtectedRoute(): JSX.Element {
   const { user, isLoading } = useAuth();
+  const location = useLocation();
 
-  if (isLoading || !user) {
+  if (isLoading) {
+    return <LoadingScreen />;
+  }
+
+  if (!user) {
+    let redirectMessage: string | null = null;
+    if (typeof window !== 'undefined') {
+      redirectMessage = window.sessionStorage.getItem('authRedirectMessage');
+      if (redirectMessage) {
+        window.sessionStorage.removeItem('authRedirectMessage');
+      }
+    }
+
     return (
-      <div className="flex h-screen w-full items-center justify-center" role="status" aria-live="polite">
-        <div className="h-12 w-12 animate-spin rounded-full border-4 border-muted border-t-primary" aria-hidden="true" />
-        <span className="sr-only">加载中...</span>
-      </div>
+      <Navigate
+        to="/login"
+        replace
+        state={{
+          from: `${location.pathname}${location.search}${location.hash}`,
+          message: redirectMessage ?? '登录状态已失效，请重新登录。',
+        }}
+      />
     );
   }
 
   return (
     <SyncProvider>
-      <RouterProvider router={router} />
+      <Outlet />
     </SyncProvider>
   );
 }
 
+const router = createBrowserRouter([
+  {
+    path: '/login',
+    element: <LoginPage />,
+  },
+  {
+    element: <ProtectedRoute />,
+    children: [
+      {
+        path: '/',
+        element: <LayoutWrapper />,
+        children: [
+          {
+            path: '/',
+            element: <Dashboard />,
+          },
+          {
+            path: 'review',
+            element: <ReviewPage />,
+          },
+          {
+            path: 'decks',
+            element: <DecksPage />,
+          },
+          {
+            path: 'decks/:deckId',
+            element: <DeckDetailPage />,
+          },
+          {
+            path: 'stats',
+            element: <StatsPage />,
+          },
+          {
+            path: 'settings',
+            element: <SettingsPage />,
+          },
+        ],
+      },
+    ],
+  },
+]);
+
 export default function App(): JSX.Element {
   return (
     <AuthProvider>
-      <ProtectedApp />
+      <RouterProvider router={router} />
     </AuthProvider>
   );
 }

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -1,13 +1,18 @@
-import { Search, Settings, User, Moon, Sun, RefreshCw, AlertTriangle } from "lucide-react";
+import { Search, Settings, User, Moon, Sun, RefreshCw, AlertTriangle, LogOut } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSync } from "@/hooks/useSyncEngine";
 import { formatRelativeTime } from "@/lib/dateUtils";
+import { useAuth } from "@/hooks/useAuth";
 
 export function Header() {
   const [darkMode, setDarkMode] = useState(() => document.documentElement.classList.contains('dark'));
   const { sync, isSyncing, lastSyncedAt, error, status } = useSync();
+  const { user, signOut } = useAuth();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [signOutError, setSignOutError] = useState<string | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   const toggleDarkMode = () => {
     const newDarkMode = !darkMode;
@@ -25,6 +30,43 @@ export function Header() {
       document.documentElement.classList.toggle('dark', isDark);
     }
   }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
+  const handleSignOut = async () => {
+    setSignOutError(null);
+    try {
+      sessionStorage.setItem('authRedirectMessage', '您已退出登录。');
+      await signOut();
+    } catch (err) {
+      sessionStorage.removeItem('authRedirectMessage');
+      const message = err instanceof Error ? err.message : '退出登录失败，请稍后重试。';
+      setSignOutError(message);
+    } finally {
+      setIsMenuOpen(false);
+    }
+  };
+
+  const userEmail = user?.email ?? '未登录用户';
 
   return (
     <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 fixed top-0 w-full z-50">
@@ -77,12 +119,46 @@ export function Header() {
             <Settings className="h-4 w-4" />
             <span className="sr-only">Settings</span>
           </Button>
-          <Button variant="ghost" size="sm">
-            <User className="h-4 w-4" />
-            <span className="sr-only">User Profile</span>
-          </Button>
+          <div className="relative" ref={menuRef}>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex items-center gap-2"
+              onClick={() => { setIsMenuOpen((prev) => !prev); }}
+              aria-haspopup="menu"
+              aria-expanded={isMenuOpen}
+            >
+              <User className="h-4 w-4" />
+              <span className="hidden sm:inline-flex text-sm">{userEmail}</span>
+            </Button>
+            {isMenuOpen ? (
+              <div
+                className="absolute right-0 mt-2 w-52 rounded-md border bg-popover p-2 text-sm shadow-md"
+                role="menu"
+                aria-label="用户菜单"
+              >
+                <div className="px-2 py-1 text-xs text-muted-foreground">已登录为</div>
+                <div className="px-2 pb-2 text-sm font-medium break-words">{userEmail}</div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start gap-2"
+                  onClick={handleSignOut}
+                  role="menuitem"
+                >
+                  <LogOut className="h-4 w-4" />
+                  退出登录
+                </Button>
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
+      {signOutError ? (
+        <div className="border-t border-destructive/20 bg-destructive/10 px-4 py-2 text-center text-xs text-destructive" role="alert">
+          {signOutError}
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/packages/frontend/src/pages/LoginPage.tsx
+++ b/packages/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,93 @@
+import { FormEvent, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuth } from '@/hooks/useAuth';
+
+interface LoginLocationState {
+  from?: string;
+  message?: string;
+}
+
+export function LoginPage(): JSX.Element {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = (location.state as LoginLocationState | undefined) ?? {};
+  const { signIn } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await signIn({ email, password });
+      const destination = state.from ?? '/';
+      navigate(destination, { replace: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '无法登录，请稍后重试。';
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4">
+      <div className="w-full max-w-md rounded-lg border bg-background p-8 shadow-sm">
+        <h1 className="text-2xl font-semibold tracking-tight text-center">欢迎回来</h1>
+        <p className="mt-2 text-center text-sm text-muted-foreground">
+          {state.message ?? '请登录以访问您的学习数据。'}
+        </p>
+
+        {error ? (
+          <div className="mt-4 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive" role="alert">
+            {error}
+          </div>
+        ) : null}
+
+        <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="email">邮箱</Label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="password">密码</Label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="请输入密码"
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? '登录中…' : '登录'}
+          </Button>
+        </form>
+
+        <p className="mt-6 text-center text-xs text-muted-foreground">
+          使用您在 Supabase 中配置的账号信息登录。
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated Supabase email/password login page and route
- guard application routes behind a ProtectedRoute that redirects unauthenticated users to /login with helpful messaging
- enhance the header with an authenticated user dropdown that supports signing out and surfaces sign-out errors

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f6224ac88323a1d28843e03b0a45