### PR TITLE
Adjust Turbo seed and test setup dependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -37,12 +37,10 @@
       "outputs": []
     },
     "seed": {
-      "dependsOn": ["migrate"],
       "cache": false,
       "outputs": []
     },
     "test:setup": {
-      "dependsOn": ["seed"],
       "cache": false,
       "outputs": []
     },


### PR DESCRIPTION
## Summary
- remove the automatic migrate dependency from the seed and test:setup turbo tasks
- keep the test task chained to test:setup so prepare-test-db still orchestrates migrations when a database URL exists

## Testing
- ./scripts/run-backend-tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68da45b91da08323af95066b46075503