### PR TITLE
Add Supabase bootstrap script for devcontainer startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,5 +13,5 @@
         }
 	},
 	"postCreateCommand": "bun install -g pm2 && echo 'export PATH=$PATH:/home/vscode/.bun/bin' >> /home/vscode/.bashrc",
-	"postStartCommand": "supabase start && supabase status -o env --override-name db.url=DATABASE_URL --override-name auth.jwt_secret=SUPABASE_JWT_SECRET --override-name auth.anon_key=SUPABASE_ANON_KEY --override-name auth.service_role_key=SUPABASE_SERVICE_ROLE_KEY > supabase/.env"
+        "postStartCommand": "./scripts/devcontainer/bootstrap-supabase.sh"
 }

--- a/scripts/devcontainer/bootstrap-supabase.sh
+++ b/scripts/devcontainer/bootstrap-supabase.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This helper is invoked by the devcontainer post-start hook to ensure the local Supabase stack
+# is running and that the generated credentials in supabase/.env stay in sync. If the CLI state
+# becomes stale (for example after manually stopping containers), rerun this script manually from
+# the repository root: ./scripts/devcontainer/bootstrap-supabase.sh
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+ENV_FILE="${REPO_ROOT}/supabase/.env"
+
+cd "${REPO_ROOT}"
+
+mkdir -p "$(dirname "${ENV_FILE}")"
+
+STATUS_OUTPUT=""
+if STATUS_OUTPUT=$(supabase status 2>&1); then
+  echo "Supabase stack already running."
+else
+  echo "Supabase stack not running. Starting it now..."
+  echo "${STATUS_OUTPUT}"
+  supabase start
+fi
+
+printf 'Waiting for Supabase services to become ready'
+until supabase status > /dev/null 2>&1; do
+  printf '.'
+  sleep 2
+done
+printf '\n'
+
+supabase status -o env \
+  --override-name db.url=DATABASE_URL \
+  --override-name auth.jwt_secret=SUPABASE_JWT_SECRET \
+  --override-name auth.anon_key=SUPABASE_ANON_KEY \
+  --override-name auth.service_role_key=SUPABASE_SERVICE_ROLE_KEY \
+  > "${ENV_FILE}"
+
+echo "Supabase environment exported to ${ENV_FILE}"


### PR DESCRIPTION
## Summary
- add a devcontainer bootstrap script that idempotently starts Supabase and refreshes the exported env file
- update the devcontainer post-start hook to invoke the helper script

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da4befac4c83239503f89b28b1d33c